### PR TITLE
docs: minor cleanup

### DIFF
--- a/crates/achroma/CHANGELOG.md
+++ b/crates/achroma/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased (YYYY-MM-DD)
+
+- docs: make documentation for `ConeCellSummary::NORMAL` consistent with other constants
+
 ## 0.1.0 (2023-10-29)
 
 - Initial release of the achroma library

--- a/crates/achroma/CHANGELOG.md
+++ b/crates/achroma/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (YYYY-MM-DD)
 
 - docs: make documentation for `ConeCellSummary::NORMAL` consistent with other constants
+- docs: remove commented out methods in `ColorVision`
 
 ## 0.1.0 (2023-10-29)
 

--- a/crates/achroma/src/lib.rs
+++ b/crates/achroma/src/lib.rs
@@ -122,7 +122,7 @@ pub struct ConeCellSummary {
 }
 
 impl ConeCellSummary {
-	/// Normal trichromatic vision
+	/// see documentation for [`ColorVision::Normal`]
 	pub const NORMAL: Self = Self::new(
 		ConeCellCond::Normal,
 		ConeCellCond::Normal,
@@ -594,9 +594,6 @@ pub enum ColorVision {
 }
 
 impl ColorVision {
-	// pub fn get_cone_condition(&self, cone: Cone) -> ConeCondition;
-	// pub fn as_cone_conditions(&self): EyeCondition;
-
 	/// Returns whether the color vision is red-green color vision deficiency (CVD).
 	///
 	/// This returns true if the color vision is either protanomaly, protanopia,

--- a/crates/achroma/src/lib.rs
+++ b/crates/achroma/src/lib.rs
@@ -122,7 +122,7 @@ pub struct ConeCellSummary {
 }
 
 impl ConeCellSummary {
-	/// see documentation for [`ColorVision::Normal`]
+	/// See documentation for [`ColorVision::Normal`]
 	pub const NORMAL: Self = Self::new(
 		ConeCellCond::Normal,
 		ConeCellCond::Normal,


### PR DESCRIPTION
- docs: make documentation for `ConeCellSummary::NORMAL` consistent with other constants
- docs: remove commented out methods in `ColorVision`