### PR TITLE
tests: add unit test for error case

### DIFF
--- a/crates/achroma/src/lib.rs
+++ b/crates/achroma/src/lib.rs
@@ -1209,5 +1209,13 @@ mod tests {
 			ColorVision::try_from(ConeCellSummary::ACHROMATOPSIA),
 			Ok(ColorVision::Achromatopsia)
 		);
+		assert_eq!(
+			ColorVision::try_from(ConeCellSummary::new(
+				ConeCellCond::Anomalous,
+				ConeCellCond::Anomalous,
+				ConeCellCond::Anomalous
+			)),
+			Err(())
+		);
 	}
 }


### PR DESCRIPTION
adds unit test for error case for `ColorVision`'s impl of `TryFrom<ConeCellSummary>`